### PR TITLE
Added FONTCONFIG_FILE and FONTCONFIG_PATH system environment variables

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,3 +28,12 @@ rm -Rf "${PREFIX}/var/cache/fontconfig"
 # Leave cache directory, in case it's needed
 mkdir -p "${PREFIX}/var/cache/fontconfig"
 touch "${PREFIX}/var/cache/fontconfig/.leave"
+
+#Add FONTCONFIG_PATH and FONTCONFIG_FILE to the enviroment variables
+ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+mkdir -p $ACTIVATE_DIR
+mkdir -p $DEACTIVATE_DIR
+
+cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/fontconfig-activate.sh
+cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/fontconfig-deactivate.sh

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [[ -z "$FONTCONFIG_FILE" ]]; then
+    export FONTCONFIG_FILE=\$CONDA_PREFIX/etc/fonts/fonts.conf
+    export FONTCONFIG_PATH=\$CONDA_PREFIX/etc/fonts/
+fi

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [[ -z "$FONTCONFIG_FILE" ]]; then
-    export FONTCONFIG_FILE=\$CONDA_PREFIX/etc/fonts/fonts.conf
-    export FONTCONFIG_PATH=\$CONDA_PREFIX/etc/fonts/
+    export FONTCONFIG_FILE=$CONDA_PREFIX/etc/fonts/fonts.conf
+    export FONTCONFIG_PATH=$CONDA_PREFIX/etc/fonts/
 fi

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,0 +1,4 @@
+if [[ -n "$FONTCONFIG_FILE" ]]; then
+	unset FONTCONFIG_FILE
+	unset FONTCONFIG_PATH
+fi


### PR DESCRIPTION
This PR adds an automatic configuration of the FONTCONFIG_FILE and FONTCONFIG_PATH system environment variables that software like 'hicup' needs. I think these two variables should be set by the conda package itself and not by the tools that depend on fontconfig and the presence of these two variables. 

Thanks a lot for reviewing. 