### PR TITLE
Drop the library search hack for running the tests

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
 
-if [[ $(uname) == 'Darwin' ]];
-then
-    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-elif [[ $(uname) == 'Linux' ]];
-then
-    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-fi
+# Drop when switching to the new `compiler` syntax.
+export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
 
 sed -i.orig s:'@PREFIX@':"${PREFIX}":g src/fccfg.c
 
@@ -20,8 +15,8 @@ chmod +x configure
       --with-add-fonts=${PREFIX}/fonts
 
 make -j${CPU_COUNT}
-eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
-eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make install
+make check
+make install
 
 # Remove computed cache with local fonts
 rm -Rf "${PREFIX}/var/cache/fontconfig"


### PR DESCRIPTION
As this is a rather old feedstock, it relied on a hack on macOS and Linux to ensure libraries were loaded correctly when running the tests as `conda-build` had not worked it's prefix magic to fix the paths in binaries to load them from the correct location. The workaround was to set the library fallback paths for loading these libraries to search in the correct location when nothing else worked. However SIP on macOS 10.11 made this no longer a viable solution. To fix this issue, simply set the `rpath` correctly on macOS and Linux when building libraries. This way the libraries will already have the right location to load linked dependencies from and there is no need for the hack. Of course `conda-build` will still do binary prefix substitution, which is fine as well.