### PR TITLE
Stop packaging Libtool `.la` files.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-
 sed -i.orig s:'@PREFIX@':"${PREFIX}":g src/fccfg.c
+
+# Cf. https://github.com/conda-forge/staged-recipes/issues/673, we're in the
+# process of excising Libtool files from our packages. Existing ones can break
+# the build while this happens.
+find $PREFIX -name '*.la' -delete
 
 autoreconf -f -i
 
@@ -14,6 +18,10 @@ autoreconf -f -i
 make -j${CPU_COUNT}
 make check
 make install
+
+# Remove any new Libtool files we may have installed. It is intended that
+# conda-build will eventually do this automatically.
+find $PREFIX -name '*.la' -delete
 
 # Remove computed cache with local fonts
 rm -Rf "${PREFIX}/var/cache/fontconfig"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - fcf.patch       # [linux]
 
 build:
-  number: 2
+  number: 3
   skip: True                       # [win]
   binary_has_prefix_files:         # [linux]
     - lib/libfontconfig.so.1.11.1  # [linux]


### PR DESCRIPTION
Pursuant to https://github.com/conda-forge/staged-recipes/issues/673 and https://github.com/conda-forge/libxcb-feedstock/pull/9, we're going to remove these files from our packages. Eventually conda-build will do this automatically for us, but for now we take care of it manually. We need to delete the files both before the build (because inconsistent complements of `.la` files can break the build) and after (because we may have installed new ones).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
